### PR TITLE
fix bug @webroot for default uploadDir

### DIFF
--- a/KCFinder.php
+++ b/KCFinder.php
@@ -90,7 +90,7 @@ class KCFinder extends \yii\widgets\InputWidget
         parent::init();
 
         $this->kcfOptions['uploadURL'] = ArrayHelper::getValue($this->kcfOptions, 'uploadURL', '@web/upload');
-        $this->kcfOptions['uploadDir'] = ArrayHelper::getValue($this->kcfOptions, 'uploadDir', '@app/web/upload');
+        $this->kcfOptions['uploadDir'] = ArrayHelper::getValue($this->kcfOptions, 'uploadDir', '@webroot/upload');
         $this->kcfOptions['uploadURL'] = Yii::getAlias($this->kcfOptions['uploadURL']);
         $this->kcfOptions['uploadDir'] = Yii::getAlias($this->kcfOptions['uploadDir']);
         


### PR DESCRIPTION
http://www.yiiframework.com/doc-2.0/guide-concept-aliases.html#predefined-aliases

> @webroot, the Web root directory of the currently running Web application. It is determined based on the directory containing the entry script.

`@webroot` better of `@app/web` by default.
