### PR TITLE
Adding ckeditor widget

### DIFF
--- a/CKEditor.php
+++ b/CKEditor.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @author Yuriy Mamaev
+ */
+
+namespace iutbay\yii2kcfinder;
+
+
+use yii\helpers\ArrayHelper;
+
+class CKEditor extends \dosamigos\ckeditor\CKEditor
+{
+
+    public $enableKCFinder = true;
+
+    /**
+     * Registers CKEditor plugin
+     */
+    protected function registerPlugin()
+    {
+        if ($this->enableKCFinder)
+        {
+            $this->registerKCFinder();
+        }
+
+        parent::registerPlugin();
+    }
+
+    /**
+     * Registers KCFinder
+     */
+    protected function registerKCFinder()
+    {
+        $register = \iutbay\yii2kcfinder\KCFinderAsset::register($this->view);
+        $kcfinderUrl = $register->baseUrl;
+
+        $browseOptions = [
+            'filebrowserBrowseUrl' => $kcfinderUrl . '/browse.php?opener=ckeditor&type=files&lang=' . \yii::$app->language,
+            'filebrowserUploadUrl' => $kcfinderUrl . '/upload.php?opener=ckeditor&type=files&lang=' . \yii::$app->language,
+        ];
+
+        $this->clientOptions = ArrayHelper::merge($browseOptions, $this->clientOptions);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -53,51 +53,12 @@ echo $form->field($model, 'images')->widget(KCFinderInputWidget::className(), [
 
 Use with 2amigos/yii2-ckeditor-widget
 -------------------------------------
-You should extend ```\dosamigos\ckeditor\CKEditor```, e.g. :
+You should use extended CKEditor widget ```iutbay\yii2kcfinder\CKEditor```, e.g. :
 
 ```php
-namespace app\widgets;
-
-use yii\helpers\ArrayHelper;
-
-use iutbay\yii2kcfinder\KCFinderAsset;
-
-class CKEditor extends \dosamigos\ckeditor\CKEditor
-{
-
-	public $enableKCFinder = true;
-
-	/**
-	 * Registers CKEditor plugin
-	 */
-	protected function registerPlugin()
-	{
-		if ($this->enableKCFinder)
-		{
-			$this->registerKCFinder();
-		}
-
-		parent::registerPlugin();
-	}
-
-	/**
-	 * Registers KCFinder
-	 */
-	protected function registerKCFinder()
-	{
-		$register = KCFinderAsset::register($this->view);
-		$kcfinderUrl = $register->baseUrl;
-
-		$browseOptions = [
-			'filebrowserBrowseUrl' => $kcfinderUrl . '/browse.php?opener=ckeditor&type=files',
-			'filebrowserUploadUrl' => $kcfinderUrl . '/upload.php?opener=ckeditor&type=files',
-		];
-
-		$this->clientOptions = ArrayHelper::merge($browseOptions, $this->clientOptions);
-	}
-
-}
+\iutbay\yii2kcfinder\CKEditor::widget();
 ```
+Widget has enableKCFinder option for enable\disable KCFinder.
 
 You should then set KCFinder options using session var, e.g. :
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
 		"sunhater/kcfinder": "*",
 		"yiisoft/yii2-bootstrap": "*",
 		"yiisoft/yii2-jui": "*",
-		"iutbay/yii2-fontawesome" : "dev-master"
+		"iutbay/yii2-fontawesome" : "@dev",
+		"2amigos/yii2-ckeditor-widget": "@dev"
 	},
 	"autoload": {
 		"psr-4": {"iutbay\\yii2kcfinder\\": ""}


### PR DESCRIPTION
To eliminate copy-paste, moved the editor widget from the documentation to a separate class.